### PR TITLE
Changed Markdown.hs for Pandoc >=1.10 compatibility

### DIFF
--- a/src/Text/Markdown.hs
+++ b/src/Text/Markdown.hs
@@ -3,14 +3,18 @@ module Text.Markdown (toHTML) where
 import Text.Pandoc
   ( readMarkdown
   , writeHtmlString
-  , defaultParserState
-  , defaultWriterOptions
+  , ReaderOptions
+  , WriterOptions
+  , def
   )
+
 import Data.ByteString.Lazy.Char8 (ByteString, pack)
 
+readMD = readMarkdown def
+writeHTMLStr = writeHtmlString def
 -- Function for translating Markdown to HTML since `Pandoc` has several
 -- different generators for other markup languages.
 toHTML :: String -> ByteString
-toHTML = pack . writeHtmlString defaultWriterOptions . parse
-  where parse = readMarkdown defaultParserState
+toHTML = pack . writeHTMLStr . parse
+  where parse = readMD 
 {-# INLINE toHTML #-}

--- a/src/Text/Markdown.hs
+++ b/src/Text/Markdown.hs
@@ -1,20 +1,19 @@
 module Text.Markdown (toHTML) where
 
 import Text.Pandoc
-  ( readMarkdown
+  ( Pandoc
+  , readMarkdown
   , writeHtmlString
-  , ReaderOptions
-  , WriterOptions
   , def
   )
 
 import Data.ByteString.Lazy.Char8 (ByteString, pack)
 
-readMD = readMarkdown def
+writeHTMLStr :: Pandoc -> String
 writeHTMLStr = writeHtmlString def
 -- Function for translating Markdown to HTML since `Pandoc` has several
 -- different generators for other markup languages.
 toHTML :: String -> ByteString
 toHTML = pack . writeHTMLStr . parse
-  where parse = readMD 
+  where parse = readMarkdown def
 {-# INLINE toHTML #-}


### PR DESCRIPTION
I've tried to run hyakko on my local machine, but it wouldn't install because Pandoc has changed from version 1.9 to 1.10. I've made the required changes to make it run with 1.10. This is my first pull request, and I'm also very new to Haskell, so please excuse any obvious flaws. I'm eager to learn though. Sincerely, Psirus
